### PR TITLE
Fix CEvNS cross-section physics bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+examples/cpp/basic_rate_calculator
+examples/cpp/mc_event_generator
+examples/python/__pycache__/
+*.pyc

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,9 +83,12 @@ dσ/dT = (G_F² M_A)/(4π) · Q_W² · F²(Q²) · [1 - (M_A T)/(2 E_ν²)]
 - F(Q²) = Helm form factor
 
 **Detector-Specific Values**:
-- Germanium-73: A=73, Z=32, Q_W≈29.4, quenching=0.20
-- Xenon-131: A=131, Z=54, Q_W≈46.6, quenching=0.15
-- Argon-40: A=40, Z=18, Q_W≈16.0, quenching=0.23
+- Germanium-73: A=73, Z=32, Q_W≈38.6, quenching=0.20
+- Xenon-131: A=131, Z=54, Q_W≈72.9, quenching=0.15
+- Argon-40: A=40, Z=18, Q_W≈20.6, quenching=0.23
+- Cesium-133: A=133, Z=55, Q_W≈73.9, quenching=0.08
+
+(Q_W = N − Z(1 − 4·sin²θ_W) with sin²θ_W = 0.23121.)
 
 **Typical Event Rates** (1 kg Ge, 25m, 3 GW reactor):
 - No threshold: ~100 events/day

--- a/docs/CEVNS_REACTOR_QUICKSTART.md
+++ b/docs/CEVNS_REACTOR_QUICKSTART.md
@@ -85,10 +85,11 @@ Where:
 
 ### Coherent Enhancement
 
-For typical nuclei:
-- **Germanium-73** (A=73, Z=32): Q_W ≈ 29.4, σ ∝ 865
-- **Xenon-131** (A=131, Z=54): Q_W ≈ 46.6, σ ∝ 2172
-- **Argon-40** (A=40, Z=18): Q_W ≈ 16.0, σ ∝ 256
+For typical nuclei (Q_W = N − Z(1 − 4·sin²θ_W), sin²θ_W = 0.23121):
+- **Germanium-73** (A=73, Z=32): Q_W ≈ 38.6, σ ∝ 1490
+- **Xenon-131** (A=131, Z=54): Q_W ≈ 72.9, σ ∝ 5320
+- **Argon-40** (A=40, Z=18): Q_W ≈ 20.6, σ ∝ 426
+- **Cesium-133** (A=133, Z=55): Q_W ≈ 73.9, σ ∝ 5457
 
 This N² scaling makes CEvNS favorable for heavy target materials.
 
@@ -815,11 +816,12 @@ HBARC = 0.1973  # GeV fm
 **Weak Charges** (Q_W):
 | Nucleus | A | Z | Q_W | Enhancement (Q_W²) |
 |---------|---|---|-----|-------------------|
-| ²³Na | 23 | 11 | 9.6 | 92 |
-| ⁴⁰Ar | 40 | 18 | 16.0 | 256 |
-| ⁷³Ge | 73 | 32 | 29.4 | 865 |
-| ¹²⁷I | 127 | 53 | 44.7 | 1998 |
-| ¹³¹Xe | 131 | 54 | 46.6 | 2172 |
+| ²³Na | 23 | 11 | 11.2 | 125 |
+| ⁴⁰Ar | 40 | 18 | 20.6 | 426 |
+| ⁷³Ge | 73 | 32 | 38.6 | 1490 |
+| ¹²⁷I | 127 | 53 | 70.0 | 4900 |
+| ¹³¹Xe | 131 | 54 | 72.9 | 5320 |
+| ¹³³Cs | 133 | 55 | 73.9 | 5457 |
 
 **Quenching Factors** (nuclear recoil to electron equivalent):
 - Germanium: q = 0.20 ± 0.02
@@ -888,7 +890,7 @@ python cevns_calculator.py --detector Ge --mass 1.0 --baseline 25.0 --power 3.0
 # Output:
 # Reactor: 3.0 GW at 25.0 m
 # Detector: 1.0 kg Germanium-73
-# Weak charge Q_W: 29.4
+# Weak charge Q_W: 38.6
 # Event rate (no threshold): 102.3 events/day
 # Event rate (0.2 keV_ee): 67.8 events/day
 # Event rate (0.5 keV_ee): 31.2 events/day

--- a/examples/README.md
+++ b/examples/README.md
@@ -100,7 +100,7 @@ Detector Configuration:
   Material: Germanium (A=73, Z=32)
   Mass: 1.0 kg
   Number of targets: 8.27e+24 nuclei
-  Weak charge Q_W: 29.4
+  Weak charge Q_W: 38.6
   Quenching factor: 0.20
 
 Physics Parameters:
@@ -275,7 +275,7 @@ Configuration:
   Detector: 1.0 kg Germanium-73 (A=73, Z=32)
 
 Physics:
-  Weak charge Q_W: 29.40
+  Weak charge Q_W: 38.60
   Number of targets: 8.267e+24
 
 Results:

--- a/examples/cpp/basic_rate_calculator.cpp
+++ b/examples/cpp/basic_rate_calculator.cpp
@@ -21,7 +21,7 @@ const double GF = 1.1663787e-5;  // GeV^-2, Fermi constant
 const double SIN2TW = 0.23121;   // sin^2(theta_W)
 const double HBARC = 0.1973;     // GeV·fm
 const double MEV_TO_GEV = 0.001;
-const double CM2_TO_GEV2 = 2.568e-31;
+const double CM2_TO_GEV2 = 2.568e+27;  // 1 cm^2 in GeV^-2 via (hbar*c)^2
 const double NA = 6.022e23;      // Avogadro's number
 const double AMU_TO_KG = 1.66054e-27;  // Atomic mass unit to kg
 
@@ -41,12 +41,12 @@ double helm_form_factor(double Q2_GeV2, double A) {
     double qRA = q * RA;
     double qs = q * s;
 
-    // Spherical Bessel function j1(x)/x
+    // Spherical Bessel function j1(x)/x = (sin x - x cos x)/x^3
     double j1_over_qRA;
     if (qRA < 0.01) {
         j1_over_qRA = 1.0/3.0 - qRA*qRA/30.0;
     } else {
-        j1_over_qRA = (std::sin(qRA)/qRA - std::cos(qRA)) / qRA;
+        j1_over_qRA = (std::sin(qRA) - qRA*std::cos(qRA)) / (qRA*qRA*qRA);
     }
 
     double F = 3.0 * j1_over_qRA * std::exp(-qs*qs/2.0);

--- a/examples/cpp/mc_event_generator.cpp
+++ b/examples/cpp/mc_event_generator.cpp
@@ -12,6 +12,7 @@
  */
 
 #include <iostream>
+#include <iomanip>
 #include <fstream>
 #include <cmath>
 #include <cstring>
@@ -24,7 +25,7 @@ const double GF = 1.1663787e-5;
 const double SIN2TW = 0.23121;
 const double HBARC = 0.1973;
 const double MEV_TO_GEV = 0.001;
-const double CM2_TO_GEV2 = 2.568e-31;
+const double CM2_TO_GEV2 = 2.568e+27;  // 1 cm^2 in GeV^-2 via (hbar*c)^2
 
 // Default parameters
 struct SimConfig {
@@ -56,11 +57,12 @@ double helm_form_factor(double Q2_GeV2, double A) {
     double qRA = q * RA;
     double qs = q * s;
 
+    // Spherical Bessel function j1(x)/x = (sin x - x cos x)/x^3
     double j1_over_qRA;
     if (qRA < 0.01) {
         j1_over_qRA = 1.0/3.0 - qRA*qRA/30.0;
     } else {
-        j1_over_qRA = (std::sin(qRA)/qRA - std::cos(qRA)) / qRA;
+        j1_over_qRA = (std::sin(qRA) - qRA*std::cos(qRA)) / (qRA*qRA*qRA);
     }
 
     double F = 3.0 * j1_over_qRA * std::exp(-qs*qs/2.0);

--- a/examples/python/cevns_calculator.py
+++ b/examples/python/cevns_calculator.py
@@ -20,7 +20,7 @@ GF = 1.1663787e-5  # GeV^-2, Fermi constant
 SIN2TW = 0.23121   # sin^2(theta_W), weak mixing angle
 HBARC = 0.1973     # GeV fm, conversion factor
 MEV_TO_GEV = 0.001
-CM2_TO_GEV2 = 2.568e-31  # Conversion from GeV^-2 to cm^2
+CM2_TO_GEV2 = 2.568e+27  # 1 cm^2 in GeV^-2; equivalently, 1 GeV^-2 = (hbar*c)^2 ≈ 3.894e-28 cm^2
 
 # Detector properties database
 DETECTORS = {
@@ -70,18 +70,18 @@ def helm_form_factor(Q2_GeV2, A):
     qRA = q * RA
     qs = q * s
 
-    # Spherical Bessel function j1(x)/x
+    # Spherical Bessel function j1(x)/x = (sin x - x cos x)/x^3
     # Use Taylor expansion for small x to avoid numerical issues
     if np.isscalar(qRA):
         if qRA < 0.01:
             j1_over_qRA = 1.0/3.0 - qRA**2/30.0
         else:
-            j1_over_qRA = (np.sin(qRA)/qRA - np.cos(qRA)) / qRA
+            j1_over_qRA = (np.sin(qRA) - qRA*np.cos(qRA)) / qRA**3
     else:
         j1_over_qRA = np.where(
             qRA < 0.01,
             1.0/3.0 - qRA**2/30.0,  # Taylor expansion
-            (np.sin(qRA)/qRA - np.cos(qRA)) / qRA
+            (np.sin(qRA) - qRA*np.cos(qRA)) / qRA**3
         )
 
     # Helm form factor
@@ -128,9 +128,11 @@ def cevns_dsigma_dT(E_nu_MeV, T_recoil_MeV, A, Z):
     dsigma = (GF**2 * MA_GeV) / (4.0 * np.pi)
     dsigma *= QW**2 * F2 * kinematic
 
-    # Convert to cm^2/MeV
-    dsigma /= CM2_TO_GEV2  # GeV^-2 to cm^2
-    dsigma /= MEV_TO_GEV   # per GeV to per MeV
+    # Convert from natural units (GeV^-3) to cm^2/MeV:
+    # 1) GeV^-3 -> cm^2/GeV : multiply by (hbar c)^2 = 1/CM2_TO_GEV2
+    # 2) cm^2/GeV -> cm^2/MeV : multiply by (1 GeV)/(1000 MeV) = MEV_TO_GEV
+    dsigma /= CM2_TO_GEV2
+    dsigma *= MEV_TO_GEV
 
     return dsigma
 


### PR DESCRIPTION
## Resumen

El cálculo de CEvNS en `examples/python/cevns_calculator.py` y los dos `.cpp` daba números físicamente imposibles. Sección eficaz de ~`10²² cm²` (vs. ~`10⁻⁴⁰` real), factor de forma F²>1, y todas las tasas con threshold>0 daban 0. Este PR corrige tres bugs en la física y un bug de compilación en C++, además de sincronizar los valores de Q_W documentados.

## Bugs

**1. Conversión GeV⁻² → cm² con la constante invertida (10⁵⁸ de error).**
`CM2_TO_GEV2 = 2.568e-31` debería ser `2.568e+27` (= 1 cm² en GeV⁻² vía (ℏc)²). Afecta `cevns_calculator.py:23`, `basic_rate_calculator.cpp:24` y `mc_event_generator.cpp:27`.

**2. Factor de forma Helm inconsistente entre ramas.**
Las dos ramas calculaban cosas distintas:
- Taylor (`qRA < 0.01`): `1/3 − qRA²/30`, que es j₁(x)/x para x pequeño ✓
- Numérica: `(sin(qRA)/qRA − cos(qRA))/qRA`, que simplifica a `j₁(qRA)` — le falta un factor `1/qRA`

Reescritas ambas en la forma canónica `(sin x − x·cos x)/x³` que implementa j₁(x)/x directamente. Esto explica por qué F² salía > 1 fuera del régimen Taylor.

**3. Conversión per-GeV → per-MeV invertida (Python only).**
`dsigma /= MEV_TO_GEV` multiplica por 1000 cuando debería dividir (para pasar de cm²/GeV a cm²/MeV hay que multiplicar por 1/1000). Cambiado a `dsigma *= MEV_TO_GEV`. Los `.cpp` no tienen este bug porque mantienen T en GeV durante toda la integración.

**4. (bonus) `#include <iomanip>` faltante en `mc_event_generator.cpp`.**
Pre-existente, el archivo no compilaba: `'setprecision' is not a member of 'std'`.

## Sincronización de docs

Los valores de Q_W en `CLAUDE.md`, `docs/CEVNS_REACTOR_QUICKSTART.md` y `examples/README.md` (29.4 para Ge, 46.6 para Xe, 16.0 para Ar) **no coincidían** con la fórmula que el código implementa: `Q_W = N − Z(1 − 4sin²θ_W)` con `sin²θ_W = 0.23121`. Los actualicé a los valores correctos y añadí Cs-133 a la tabla:

| Núcleo | Q_W (antes) | Q_W (correcto) |
|--------|------------:|---------------:|
| Ar-40  | 16.0 | **20.6** |
| Ge-73  | 29.4 | **38.6** |
| Xe-131 | 46.6 | **72.9** |
| Cs-133 | —    | **73.9** |

## Verificación

Después de los fixes, corriendo `python3 cevns_calculator.py --detector Ge --mass 1.0 --baseline 25.0 --power 3.0`:

```
Cross section (3.0 MeV): 5.64e-41 cm²        ← antes 9.44e+21 cm²
Form factor F²(Q²=0.01 GeV²): 0.248          ← antes 1.346
Weak charge Q_W: 38.6                        ← coincide con docs actualizados
Event rate (no threshold): 663 events/day    ← antes ~10⁶⁰
```

Los ceros con threshold ≥ 0.5 keV_ee son físicamente correctos (el T_max cinemático para reactor neutrinos en Ge está por debajo de ese threshold).

Verificado también con Cs, Xe, Ar — todos dan secciones eficaces en el rango `10⁻⁴¹–10⁻⁴⁰ cm²` y F² ∈ [0, 1].

## Test plan

- [ ] `docker build -t docker-globes .` — sin cambios en Dockerfile
- [ ] `docker run --rm -v "$(pwd)/examples:/workspace" -w /workspace/python docker-globes python3 cevns_calculator.py --detector Ge` — Q_W=38.6, σ ~ 5.6e-41 cm²
- [ ] `docker run --rm -v "$(pwd)/examples:/workspace" -w /workspace/python docker-globes python3 mc_simulation.py --detector Ge --nevents 500 --output /tmp/sim --seed 42` — corre sin warnings físicos
- [ ] `docker run --rm -v "$(pwd)/examples:/workspace" -w /workspace/cpp docker-globes bash -c "make clean && make all"` — los dos binarios compilan

## Follow-ups (no incluidos)

- Los ejemplos de output en `examples/README.md` (líneas 107–116, 280–285) muestran tasas y σ del régimen con bugs (e.g. "1.23e-39 cm²", "102 events/day"). Vale la pena regenerarlos con el código corregido en un PR aparte.
- El integrador scipy avisa "max subdivisions" en algunos casos — la sección eficaz varía órdenes de magnitud sobre el rango de T, vale considerar un cambio de variable o splitting del intervalo.