### PR TITLE
Add Streamlit gallery for browsing MC outputs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,6 +157,14 @@ make clean && make all
 ./mc_event_generator --nevents 50000 --output events.csv
 ```
 
+### Streamlit Gallery
+`examples/python/gallery.py` is a small Streamlit app that browses the plots and summaries written by `mc_simulation.py`. From the host:
+```bash
+docker run --rm -p 8501:8501 -v $(pwd)/examples:/workspace -w /workspace/python \
+    docker-globes streamlit run gallery.py --server.address=0.0.0.0
+```
+Then open <http://localhost:8501>. The gallery anchors on `*_summary.txt`, so any run that produced at least a summary will appear in the sidebar.
+
 ### GLoBES Commands
 ```bash
 globes --version

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 FROM gcc:12.1.0-bullseye
 
 RUN apt-get update &&\
-    apt-get install -y libgsl-dev python3 python3-numpy python3-scipy python3-matplotlib
+    apt-get install -y libgsl-dev python3 python3-pip &&\
+    pip3 install --no-cache-dir numpy scipy matplotlib streamlit
+
+EXPOSE 8501
 
 ADD . .
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ python3 cevns_calculator.py --detector Ge --mass 1.0 --baseline 25.0 --power 3.0
 python3 mc_simulation.py --nevents 10000 --output my_simulation
 ```
 
+#### Browse results in the Streamlit gallery
+After running `mc_simulation.py` one or more times you can browse the resulting plots and summaries from a web UI:
+```bash
+docker run --rm -p 8501:8501 -v $(pwd)/examples:/workspace -w /workspace/python \
+    docker-globes streamlit run gallery.py --server.address=0.0.0.0
+```
+Then open <http://localhost:8501> in your browser. The sidebar lists every run found in `examples/python/` (anchored on `*_summary.txt`).
+
 #### Quick Example (C++)
 ```bash
 cd /workspace/cpp

--- a/examples/README.md
+++ b/examples/README.md
@@ -231,9 +231,20 @@ events = generate_cevns_events(
 plot_spectrum(events, 'my_spectrum.png')
 ```
 
+### gallery.py
+
+Streamlit app that browses every `*_summary.txt` written in this folder and shows the matching `_spectrum.png`, `_flux.png`, `_xsec.png` plus the first rows of `_events.csv` for the selected run.
+
+Launch from the host:
+```bash
+docker run --rm -p 8501:8501 -v $(pwd)/..:/workspace -w /workspace/python \
+    docker-globes streamlit run gallery.py --server.address=0.0.0.0
+```
+Then open <http://localhost:8501>. Generate runs first with `mc_simulation.py`.
+
 ### requirements.txt
 
-Install Python dependencies:
+The Docker image already ships numpy, scipy, matplotlib and streamlit, so `requirements.txt` is only needed when running outside the container:
 ```bash
 pip install -r requirements.txt
 ```
@@ -242,6 +253,7 @@ pip install -r requirements.txt
 - numpy >= 1.20
 - scipy >= 1.7
 - matplotlib >= 3.5
+- streamlit >= 1.0 (for `gallery.py`)
 
 ## C++ Examples
 

--- a/examples/python/gallery.py
+++ b/examples/python/gallery.py
@@ -1,0 +1,59 @@
+"""Streamlit gallery for CEvNS Monte Carlo simulation outputs.
+
+Scans the directory this file lives in for groups of files written by
+mc_simulation.py — `{prefix}_spectrum.png`, `{prefix}_flux.png`,
+`{prefix}_xsec.png`, `{prefix}_summary.txt` and `{prefix}_events.csv` —
+and lets the user browse them.
+
+Run from inside the container:
+    streamlit run gallery.py --server.address=0.0.0.0
+"""
+
+from pathlib import Path
+
+import streamlit as st
+
+GALLERY_DIR = Path(__file__).resolve().parent
+PLOT_KINDS = ("spectrum", "flux", "xsec")
+
+st.set_page_config(page_title="CEvNS Gallery", layout="wide")
+st.title("CEvNS Simulation Gallery")
+st.caption(f"Reading outputs from `{GALLERY_DIR}`")
+
+prefixes = sorted(
+    {p.name.removesuffix("_summary.txt") for p in GALLERY_DIR.glob("*_summary.txt")}
+)
+
+if not prefixes:
+    st.warning(
+        "No simulation outputs found. Generate some with:\n\n"
+        "```\npython3 mc_simulation.py --detector Ge --output demo --seed 42\n```"
+    )
+    st.stop()
+
+selected = st.sidebar.selectbox("Run", prefixes)
+
+summary_path = GALLERY_DIR / f"{selected}_summary.txt"
+if summary_path.exists():
+    st.sidebar.subheader("Summary")
+    st.sidebar.code(summary_path.read_text(), language="text")
+
+cols = st.columns(len(PLOT_KINDS))
+captions = {
+    "spectrum": "Detected recoil spectrum",
+    "flux": "Reactor antineutrino flux",
+    "xsec": "CEvNS cross section vs E_ν",
+}
+for col, kind in zip(cols, PLOT_KINDS):
+    plot_path = GALLERY_DIR / f"{selected}_{kind}.png"
+    if plot_path.exists():
+        col.image(str(plot_path), caption=captions[kind], use_container_width=True)
+    else:
+        col.info(f"`{plot_path.name}` not found")
+
+events_path = GALLERY_DIR / f"{selected}_events.csv"
+if events_path.exists():
+    with st.expander(f"Events ({events_path.name})"):
+        rows = events_path.read_text().splitlines()
+        st.write(f"{len(rows) - 1} events")
+        st.code("\n".join(rows[:21]), language="text")

--- a/examples/python/requirements.txt
+++ b/examples/python/requirements.txt
@@ -1,3 +1,4 @@
 numpy>=1.20.0
 scipy>=1.7.0
 matplotlib>=3.5.0
+streamlit>=1.0


### PR DESCRIPTION
## Resumen

App de Streamlit para hojear los outputs que produce `mc_simulation.py`. Sin nuevas dependencias del usuario — basta correr el contenedor con el puerto 8501 expuesto.

## Cómo se ve

Sidebar con un selector de "run" (cada `*_summary.txt` en `examples/python/`), tres columnas con `_spectrum.png`, `_flux.png`, `_xsec.png`, y un expander con las primeras 20 filas de `_events.csv`.

Si un plot falta (p.ej. Cs a threshold default produce 0 eventos por encima del cutoff cinemático, no genera `_spectrum.png`), la gallery muestra un placeholder en lugar de romperse.

## Cambios

- `examples/python/gallery.py`: app de Streamlit (~50 líneas)
- `Dockerfile`:
  - cambia de apt (numpy/scipy/matplotlib) a `pip install numpy scipy matplotlib streamlit`. Es **forzoso** porque las deps que jala streamlit (pandas, pyarrow, etc.) requieren un numpy más nuevo que el de bullseye, y la matplotlib compilada contra el numpy de apt rompe con `ImportError: numpy.core.multiarray failed to import`. El all-pip resuelve el ABI mismatch.
  - `EXPOSE 8501`
- `examples/python/requirements.txt`: agrega `streamlit>=1.0` (para uso fuera del contenedor)
- `README.md`, `examples/README.md`, `CLAUDE.md`: instrucciones para correr la gallery

## Cómo probar

```bash
# 1. Build (toma ~1 min más que antes por las deps de pip)
docker build -t docker-globes .

# 2. Genera al menos un run
docker run --rm --user $(id -u):$(id -g) \
  -v "$(pwd)/examples:/workspace" -w /workspace/python \
  docker-globes \
  python3 mc_simulation.py --detector Ge --nevents 2000 --output demo --seed 42

# 3. Levanta la gallery
docker run --rm -p 8501:8501 \
  -v "$(pwd)/examples:/workspace" -w /workspace/python \
  docker-globes \
  streamlit run gallery.py --server.address=0.0.0.0

# 4. Abre http://localhost:8501
```

## Base

Este PR se apoya en `fix/cevns-physics-bugs` (PR #4) para que los plots muestren números físicamente correctos. Si se merge #4 antes que éste, podemos rebasear el target a `main`.

## Test plan

- [ ] `docker build -t docker-globes .` completa sin errores
- [ ] Generar 1+ runs con `mc_simulation.py` — produce `demo_summary.txt`, `_spectrum.png`, etc.
- [ ] `streamlit run gallery.py` arranca y responde HTTP 200 en 8501
- [ ] En el navegador, el sidebar lista los runs disponibles y las imágenes se muestran al seleccionar uno
- [ ] Un run sin spectrum.png (p.ej. Cs a threshold default) muestra el placeholder y no rompe la app